### PR TITLE
Refactor raptor movement into class factory with zig-zag pauses

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
 
   <script type="module">
   import { generateScenery } from './scenery.js';
+  import { createRaptorClass } from './raptor.js';
   // ===== Dino Dusk — Pixel edition =====
 
   // -------------------------
@@ -497,23 +498,15 @@
     }
   }
 
-  class Raptor extends Dino {
-    constructor(x,y, speed, hp, dmg) { super(x,y, CONFIG.enemies.raptor.radius, speed, hp, dmg); }
-    update(dt, game){
-      const aim = game.player.pos.copy().sub(this.pos).norm();
-      this.vel = aim.scale(this.speed); this.pos.add(this.vel.copy().scale(dt));
-      this.hitPlayer(game, game.player, dt);
-      this.hitFlash = Math.max(0, this.hitFlash - dt);
-    }
-    draw(ctx){
-      const a = this.vel.angle();
-      ctx.save(); ctx.globalAlpha=.16; ctx.fillStyle="#000";
-      ctx.beginPath(); ctx.ellipse(this.pos.x, this.pos.y+this.radius*.4, this.radius, this.radius*.6, 0, 0, Math.PI*2); ctx.fill(); ctx.restore();
-      drawSprite(Sprites.raptor, this.pos.x, this.pos.y, a, this.radius/12);
-      if (this.hitFlash>0){ ctx.save(); ctx.globalAlpha = this.hitFlash*2; ctx.fillStyle='#fff';
-        ctx.beginPath(); ctx.arc(this.pos.x,this.pos.y,this.radius+3,0,Math.PI*2); ctx.fill(); ctx.restore(); }
-    }
-  }
+  const Raptor = createRaptorClass(Dino, Vec2);
+  Raptor.prototype.draw = function(ctx){
+    const a = this.vel.angle();
+    ctx.save(); ctx.globalAlpha=.16; ctx.fillStyle="#000";
+    ctx.beginPath(); ctx.ellipse(this.pos.x, this.pos.y+this.radius*.4, this.radius, this.radius*.6, 0, 0, Math.PI*2); ctx.fill(); ctx.restore();
+    drawSprite(Sprites.raptor, this.pos.x, this.pos.y, a, this.radius/12);
+    if (this.hitFlash>0){ ctx.save(); ctx.globalAlpha = this.hitFlash*2; ctx.fillStyle='#fff';
+      ctx.beginPath(); ctx.arc(this.pos.x,this.pos.y,this.radius+3,0,Math.PI*2); ctx.fill(); ctx.restore(); }
+  };
 
   class Pterodactyl extends Dino {
     constructor(x,y, speed, hp, dmg){ super(x,y, CONFIG.enemies.ptero.radius, speed, hp, dmg); this.phase = rand(0, Math.PI*2); }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node test/scenery.test.js",
-    "lint": "eslint scenery.js test/scenery.test.js"
+    "test": "node test/scenery.test.js && node test/raptor.test.js",
+    "lint": "eslint scenery.js raptor.js test/scenery.test.js test/raptor.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/raptor.js
+++ b/raptor.js
@@ -1,0 +1,34 @@
+export function createRaptorClass(Dino, Vec2, rand = Math.random) {
+  return class Raptor extends Dino {
+    constructor(x, y, speed, hp, dmg) {
+      super(x, y, 18, speed, hp, dmg);
+      this.pauseTimer = 0;
+      this.zigzagTimer = 0;
+      this.zigzagDir = 1;
+    }
+
+    update(dt, game) {
+      if (this.pauseTimer > 0) {
+        this.pauseTimer -= dt;
+        if (this.pauseTimer < 0) this.pauseTimer = 0;
+        this.vel.set(0, 0);
+      } else {
+        if (this.zigzagTimer <= 0) {
+          this.zigzagTimer = rand() * 0.4 + 0.3;
+          this.zigzagDir = rand() < 0.5 ? -1 : 1;
+          if (rand() < 0.3) {
+            this.pauseTimer = rand() * 0.5 + 0.2;
+          }
+        } else {
+          this.zigzagTimer -= dt;
+        }
+        const aim = game.player.pos.copy().sub(this.pos).norm();
+        const perp = new Vec2(-aim.y, aim.x).scale(0.5 * this.zigzagDir);
+        this.vel = aim.add(perp).norm().scale(this.speed);
+        this.pos.add(this.vel.copy().scale(dt));
+        this.hitPlayer(game, game.player, dt);
+      }
+      this.hitFlash = Math.max(0, this.hitFlash - dt);
+    }
+  };
+}

--- a/test/raptor.test.js
+++ b/test/raptor.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { createRaptorClass } from '../raptor.js';
+
+function makeRand(values) {
+  let i = 0;
+  return () => values[i++];
+}
+
+class Vec2 {
+  constructor(x = 0, y = 0) { this.x = x; this.y = y; }
+  copy() { return new Vec2(this.x, this.y); }
+  set(x, y) { this.x = x; this.y = y; return this; }
+  add(v) { this.x += v.x; this.y += v.y; return this; }
+  sub(v) { this.x -= v.x; this.y -= v.y; return this; }
+  scale(s) { this.x *= s; this.y *= s; return this; }
+  len() { return Math.hypot(this.x, this.y); }
+  norm() { const l = this.len() || 1; this.x /= l; this.y /= l; return this; }
+  angle() { return Math.atan2(this.y, this.x); }
+}
+
+class Dino {
+  constructor(x, y, r, speed, hp, dmg) {
+    this.pos = new Vec2(x, y);
+    this.vel = new Vec2(0, 0);
+    this.radius = r;
+    this.speed = speed;
+    this.hp = hp;
+    this.dmg = dmg;
+    this.hitFlash = 0;
+  }
+  hitPlayer() {}
+}
+
+// Test that raptor sets pauseTimer based on randomness
+{
+  const rand = makeRand([0.5, 0.6, 0.1, 0.5]);
+  const Raptor = createRaptorClass(Dino, Vec2, rand);
+  const game = { player: { pos: new Vec2(10, 0), radius: 16, hp: 100, invuln: 0 } };
+  const r = new Raptor(0, 0, 50, 30, 10);
+  r.update(0.1, game);
+  assert.ok(r.pauseTimer > 0);
+}
+
+// Test that raptor does not move while paused
+{
+  const Raptor = createRaptorClass(Dino, Vec2, () => 0.5);
+  const game = { player: { pos: new Vec2(10, 0), radius: 16, hp: 100, invuln: 0 } };
+  const r = new Raptor(0, 0, 50, 30, 10);
+  r.pauseTimer = 1;
+  r.update(0.5, game);
+  assert.equal(r.pos.x, 0);
+  assert.equal(r.pos.y, 0);
+  assert.ok(r.pauseTimer < 1);
+}
+
+// Test that raptor zig-zags when moving
+{
+  const rand = makeRand([0.5, 0.6, 0.9]);
+  const Raptor = createRaptorClass(Dino, Vec2, rand);
+  const game = { player: { pos: new Vec2(10, 0), radius: 16, hp: 100, invuln: 0 } };
+  const r = new Raptor(0, 0, 10, 30, 10);
+  r.update(1, game);
+  assert.ok(r.pos.y !== 0);
+  assert.ok(r.pos.x > 0);
+}
+
+console.log('Raptor tests passed');


### PR DESCRIPTION
## Summary
- create reusable `createRaptorClass` for raptor enemies
- raptors now randomly pause and zig-zag toward the player
- add unit tests for new raptor behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad36c6637c832da08668f756ede240