### PR TITLE
Add multi-level shotgun and missiles with tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
     player: {
       radius: 16, speed: 240, maxHP: 100, invuln: 0.7,
       baseFireRate: 4, baseBulletDamage: 15, bulletSpeed: 540,
-      fireRatePerLevel: 1.0, dmgPerLevel: 5, maxGunLevel: 7,
+      fireRatePerLevel: 1.0, dmgPerLevel: 5, maxGunLevel: 9,
       grenadeFuse: 0.85, grenadeRadius: 120, grenadeDamage: 140, grenadeSpeed: 420,
     },
     enemies: {
@@ -390,24 +390,28 @@
     }
     shoot(game){
       const spd = CONFIG.player.bulletSpeed, d = this.bulletDamage;
-      if (this.gunLevel >= 7) {
-        const ang = this.aim.angle();
-        const vel = Vec2.fromAngle(ang, spd * 0.8);
-        game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, d * 2, ang, {missile:true});
-      } else if (this.gunLevel >= 6) {
-        const pellets = 5;
+      const spread = Math.min(.18, .02 * (this.gunLevel-1));
+      const baseBullets = this.gunLevel >= 4 ? 2 : 1;
+      for (let i=0;i<baseBullets;i++){
+        const ang = this.aim.angle() + rand(-spread, spread);
+        const vel = Vec2.fromAngle(ang, spd);
+        game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, d, ang);
+      }
+      if (this.gunLevel >= 4 && this.gunLevel <= 6) {
+        const pelletCounts = [3,5,7];
+        const pellets = pelletCounts[this.gunLevel - 4];
         for (let i=0;i<pellets;i++){
           const ang = this.aim.angle() + rand(-0.5, 0.5);
           const vel = Vec2.fromAngle(ang, spd * 0.6);
           game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, d, ang, {life:0.35, radius:6});
         }
-      } else {
-        const spread = Math.min(.18, .02 * (this.gunLevel-1));
-        const bullets = this.gunLevel >= 4 ? 2 : 1;
-        for (let i=0;i<bullets;i++){
-          const ang = this.aim.angle() + rand(-spread, spread);
-          const vel = Vec2.fromAngle(ang, spd);
-          game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, d, ang);
+      }
+      if (this.gunLevel >= 7) {
+        const missiles = Math.min(3, this.gunLevel - 6);
+        for (let i=0;i<missiles;i++){
+          const ang = this.aim.angle();
+          const vel = Vec2.fromAngle(ang, spd * 0.8);
+          game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, d * 2, ang, {missile:true});
         }
       }
       AudioBus.blip({freq: 720, dur:.03, vol:.12});

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js",
-    "lint": "eslint scenery.js raptor.js projectiles.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js"
+    "test": "node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js",
+    "lint": "eslint scenery.js raptor.js projectiles.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/projectiles.js
+++ b/projectiles.js
@@ -22,18 +22,27 @@ export function createProjectileClasses(Entity, Vec2, Particle, rand = Math.rand
   class Missile extends Bullet {
     constructor(x, y, vel, dmg, ang) {
       super(x, y, vel, dmg, ang, 2.5, 6);
+      this.target = null;
     }
-    update(dt, game) {
-      const speed = this.vel.len();
-      let target = null;
+    findTarget(game) {
+      let closest = null;
       let dist = Infinity;
       for (const e of game.enemies) {
         if (!e.alive) continue;
         const d = Math.hypot(e.pos.x - this.pos.x, e.pos.y - this.pos.y);
-        if (d < dist) { dist = d; target = e; }
+        if (d < dist) { dist = d; closest = e; }
       }
-      if (target) {
-        const desired = target.pos.copy().sub(this.pos).norm().scale(speed);
+      return closest;
+    }
+    update(dt, game) {
+      if (!this.target) this.target = this.findTarget(game);
+      if (this.target && !this.target.alive) {
+        this.alive = false;
+        return;
+      }
+      if (this.target) {
+        const speed = this.vel.len();
+        const desired = this.target.pos.copy().sub(this.pos).norm().scale(speed);
         this.vel.add(desired.sub(this.vel).scale(0.1));
         this.ang = this.vel.angle();
       }

--- a/test/player.test.js
+++ b/test/player.test.js
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+
+class Vec2 {
+  constructor(x=0, y=0){ this.x=x; this.y=y; }
+  copy(){ return new Vec2(this.x, this.y); }
+  set(x,y){ this.x=x; this.y=y; return this; }
+  add(v){ this.x+=v.x; this.y+=v.y; return this; }
+  sub(v){ this.x-=v.x; this.y-=v.y; return this; }
+  scale(s){ this.x*=s; this.y*=s; return this; }
+  len(){ return Math.hypot(this.x, this.y); }
+  norm(){ const l=this.len()||1; this.x/=l; this.y/=l; return this; }
+  angle(){ return Math.atan2(this.y, this.x); }
+  static fromAngle(a, mag=1){ return new Vec2(Math.cos(a)*mag, Math.sin(a)*mag); }
+}
+
+const rand = (a=0,b=1)=> (a+b)/2;
+const AudioBus = { blip(){} };
+globalThis.rand = rand;
+const CONFIG = { player: { bulletSpeed: 10 } };
+
+class Player {
+  constructor(){ this.radius=16; this.aim=new Vec2(1,0); this.gunLevel=1; }
+  get bulletDamage(){ return 10; }
+  shoot(game){
+    const spd = CONFIG.player.bulletSpeed, d = this.bulletDamage;
+    const spread = Math.min(.18, .02 * (this.gunLevel-1));
+    const baseBullets = this.gunLevel >= 4 ? 2 : 1;
+    for (let i=0;i<baseBullets;i++){
+      const ang = this.aim.angle() + rand(-spread, spread);
+      const vel = Vec2.fromAngle(ang, spd);
+      game.spawnBullet(0,0,vel,d,ang);
+    }
+    if (this.gunLevel >= 4 && this.gunLevel <= 6) {
+      const pelletCounts = [3,5,7];
+      const pellets = pelletCounts[this.gunLevel - 4];
+      for (let i=0;i<pellets;i++){
+        const ang = this.aim.angle() + rand(-0.5, 0.5);
+        const vel = Vec2.fromAngle(ang, spd * 0.6);
+        game.spawnBullet(0,0,vel,d,ang,{life:0.35, radius:6});
+      }
+    }
+    if (this.gunLevel >= 7) {
+      const missiles = Math.min(3, this.gunLevel - 6);
+      for (let i=0;i<missiles;i++){
+        const ang = this.aim.angle();
+        const vel = Vec2.fromAngle(ang, spd * 0.8);
+        game.spawnBullet(0,0,vel,d * 2, ang, {missile:true});
+      }
+    }
+    AudioBus.blip({freq:720, dur:.03, vol:.12});
+  }
+}
+
+class Game {
+  constructor(){ this.bullets=[]; }
+  spawnBullet(x,y,vel,dmg,ang,opts={}){
+    if (opts.missile) this.bullets.push('missile');
+    else if (opts.life) this.bullets.push('pellet');
+    else this.bullets.push('bullet');
+  }
+}
+
+// Level 4: shotgun adds 3 pellets and keeps two bullets
+{
+  const game = new Game();
+  const p = new Player();
+  p.gunLevel = 4;
+  p.shoot(game);
+  assert.equal(game.bullets.filter(b=>b==='bullet').length, 2);
+  assert.equal(game.bullets.filter(b=>b==='pellet').length, 3);
+}
+
+// Level 6: shotgun adds 7 pellets
+{
+  const game = new Game();
+  const p = new Player();
+  p.gunLevel = 6;
+  p.shoot(game);
+  assert.equal(game.bullets.filter(b=>b==='pellet').length, 7);
+}
+
+// Level 7: fires missiles in addition to bullets
+{
+  const game = new Game();
+  const p = new Player();
+  p.gunLevel = 7;
+  p.shoot(game);
+  assert.equal(game.bullets.filter(b=>b==='missile').length, 1);
+  assert.equal(game.bullets.filter(b=>b==='bullet').length, 2);
+}
+
+// Level 9: fires 3 missiles
+{
+  const game = new Game();
+  const p = new Player();
+  p.gunLevel = 9;
+  p.shoot(game);
+  assert.equal(game.bullets.filter(b=>b==='missile').length, 3);
+}
+
+console.log('Player weapon tests passed');

--- a/test/projectiles.test.js
+++ b/test/projectiles.test.js
@@ -44,4 +44,15 @@ const { Bullet, Missile } = createProjectileClasses(Entity, Vec2, Particle, make
   assert.equal(game.particles.length, 1);
 }
 
+// Missile self-destructs if target dies
+{
+  const enemy = {pos:new Vec2(0,10), alive:true};
+  const m = new Missile(0,0,new Vec2(10,0),5,0);
+  const game = { enemies:[enemy], particles:[] };
+  m.update(0.1, game); // acquire target
+  enemy.alive = false;
+  m.update(0.1, game);
+  assert.equal(m.alive, false);
+}
+
 console.log('Projectile tests passed');


### PR DESCRIPTION
## Summary
- Keep long-range gun while adding shotgun levels firing 3, 5, and 7 pellets
- Add missile levels that launch 1–3 rockets and self-destruct when their target dies
- Raise max gun level to 9 and test new weapon behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad4f0938a8832d92430d6bb6eb25b1