### PR TITLE
Add kill-based special attack and refine grenade key

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,18 +214,26 @@
   // -------------------------
   // Input
   // -------------------------
-  const Input = { keys:new Set(), mouse:new Vec2(), mdown:false, rdown:false };
+  const Input = { keys:new Set(), mouse:new Vec2(), mdown:false, rdown:false, gdown:false, special:false };
   const keymap = (e) => e.key.length===1 ? e.key.toLowerCase() : e.key;
   window.addEventListener('keydown', (e) => {
     const k = keymap(e);
     if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight',' '].includes(e.key)) e.preventDefault();
     Input.keys.add(k);
     if (k==='p') togglePause();
-    if (k==='r') restart();
     if (k==='f') toggleFullscreen();
     if (k==='m') toggleMute();
+    if (k==='g' && !e.repeat) Input.gdown = true;
+    if (k==='r' && !e.repeat) {
+      if (game.state==='running') Input.special = true; else restart();
+    }
   });
-  window.addEventListener('keyup', (e) => { Input.keys.delete(keymap(e)); });
+  window.addEventListener('keyup', (e) => {
+    const k = keymap(e);
+    Input.keys.delete(k);
+    if (k==='g') Input.gdown = false;
+    if (k==='r') Input.special = false;
+  });
   canvas.addEventListener('mousedown', (e) => { if (e.button===0) Input.mdown = true; if (e.button===2) Input.rdown = true; });
   window.addEventListener('mouseup',   (e) => { if (e.button===0) Input.mdown = false; if (e.button===2) Input.rdown = false; });
   canvas.addEventListener('mousemove', (e) => {
@@ -392,8 +400,8 @@
       }
 
       // Grenade
-      if (Input.rdown || Input.keys.has('g')) {
-        Input.rdown = false;
+      if (Input.rdown || Input.gdown) {
+        Input.rdown = false; Input.gdown = false;
         if (this.grenades > 0) this.throwGrenade(game); else showToast('No grenades!', 'warn');
       }
       if (this.invuln > 0) this.invuln -= dt;
@@ -588,6 +596,7 @@
       this.enemySpawnCD = CONFIG.baseSpawnInterval; this.supplyCD = rand(...CONFIG.supplyEveryMinMax);
       this.highScore = Number(localStorage.getItem('dino_highscore') || 0);
       this.kills = 0; this.score = 0;
+      this.specialCharge = 0; this.specialActive = false; this.specialTimer = 0; this.specialPulseTimer = 0;
       updateHUD(this);
     }
     start(){ this.state='running'; hideOverlay(); showToast('Good luck, hunter!'); }
@@ -605,10 +614,19 @@
     }
     onKill(e){
       this.kills++; this.score += 10 * (e.isBoss ? 30 : 1) * this.day;
+      this.specialCharge = Math.min(20, this.specialCharge + 1);
       if (!e.isBoss && Math.random()<0.08) this.dropSupply(e.pos.x, e.pos.y);
       const color = e.isBoss ? '#ffd0d0' : (e instanceof Pterodactyl ? '#9de0ff' : '#6fe27e');
       for (let i=0;i<14;i++) this.particles.push(new Particle(e.pos.x, e.pos.y,
         Vec2.fromAngle(rand(0,Math.PI*2), rand(60,200)), .7, color, 2));
+    }
+    laserBlast(){
+      const x=this.player.pos.x, y=this.player.pos.y;
+      for (const e of this.enemies) {
+        if (!e.alive) continue; e.damage(9999); if (!e.alive) this.onKill(e);
+      }
+      for (let i=0;i<36;i++) this.particles.push(new Particle(x,y, Vec2.fromAngle(i/36*Math.PI*2, 280), .4, '#ff7bff', 2));
+      AudioBus.boom({freq:120, dur:.2, vol:.3});
     }
     dropSupply(x,y){ const type = Math.random() < 0.55 ? 'grenade' : 'gun'; this.supplies.push(new Supply(x,y,type)); }
     spawnBullet(x,y, vel, dmg, ang, opts={}){
@@ -677,6 +695,18 @@
       }
 
       this.player.update(dt, this);
+      if (Input.special) {
+        Input.special = false;
+        if (this.specialCharge >= 20 && !this.specialActive) {
+          this.specialActive = true; this.specialTimer = 5; this.specialPulseTimer = 0; this.specialCharge = 0;
+        }
+      }
+      if (this.specialActive) {
+        this.specialTimer -= dt; this.specialPulseTimer -= dt;
+        if (this.specialPulseTimer <= 0 && this.specialTimer > 0) { this.specialPulseTimer += 1; this.laserBlast(); }
+        if (this.specialTimer <= 0) this.specialActive = false;
+      }
+
       for (const arr of [this.bullets, this.enemies, this.grenades, this.supplies, this.particles]) {
         for (const e of arr) e.update?.(dt, this);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "eslint": "^8.57.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "elisgames",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
-    "test": "node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js",
-    "lint": "eslint scenery.js raptor.js projectiles.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js"
+    "test": "node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js",
+    "lint": "eslint scenery.js raptor.js projectiles.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/grenade.test.js test/special.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/test/grenade.test.js
+++ b/test/grenade.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+
+const Input = { gdown:false, rdown:false };
+let thrown = 0;
+class Player {
+  constructor(){ this.grenades = 2; }
+  update(){
+    if (Input.rdown || Input.gdown) {
+      Input.rdown = false; Input.gdown = false;
+      if (this.grenades > 0) { this.grenades--; thrown++; }
+    }
+  }
+}
+
+const p = new Player();
+Input.gdown = true; // press once
+p.update();
+p.update(); // held but should not throw again
+assert.equal(thrown, 1);
+Input.gdown = true; // press again
+p.update();
+assert.equal(thrown, 2);
+console.log('Grenade key test passed');

--- a/test/special.test.js
+++ b/test/special.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+
+const Input = { special:false };
+let pulses = 0;
+class Game {
+  constructor(){
+    this.specialCharge = 20;
+    this.specialActive = false;
+    this.specialTimer = 0;
+    this.specialPulseTimer = 0;
+  }
+  laserBlast(){ pulses++; }
+  update(dt){
+    if (Input.special) {
+      Input.special = false;
+      if (this.specialCharge >= 20 && !this.specialActive) {
+        this.specialActive = true; this.specialTimer = 5; this.specialPulseTimer = 0; this.specialCharge = 0;
+      }
+    }
+    if (this.specialActive) {
+      this.specialTimer -= dt; this.specialPulseTimer -= dt;
+      if (this.specialPulseTimer <= 0 && this.specialTimer > 0) { this.specialPulseTimer += 1; this.laserBlast(); }
+      if (this.specialTimer <= 0) this.specialActive = false;
+    }
+  }
+}
+
+const game = new Game();
+Input.special = true;
+game.update(0.1);
+for (let i=0;i<5;i++) game.update(1);
+assert.equal(pulses, 5);
+assert.equal(game.specialActive, false);
+console.log('Special attack test passed');


### PR DESCRIPTION
## Summary
- Add input handling for a kill-based special attack triggered by `R`
- Fix grenade key so `G` throws only a single grenade per press
- Bump version to 1.2.0 and include new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad61fd7bbc832d8f388522712f9210