### PR TITLE
Implement scrolling scenery and dark green background

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       font: 14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial;
       overflow: hidden;
     }
-    #game { display: block; width: 100vw; height: 100vh; background: #0b0f15; cursor: crosshair; }
+    #game { display: block; width: 100vw; height: 100vh; background: #002b11; cursor: crosshair; }
     .hud {
       position: fixed; left: 12px; top: 12px; user-select: none; pointer-events: none;
       background: linear-gradient(180deg, rgba(18,23,34,.9), rgba(12,15,20,.8));
@@ -139,7 +139,7 @@
   <div id="toast"></div>
 
   <script type="module">
-    import { generateScenery } from './scenery.js';
+    import { Scenery, generateScenery, scrollScenery } from './scenery.js';
     import { createRaptorClass } from './raptor.js';
     import { createProjectileClasses } from './projectiles.js';
     import { createMeteorClass, specialBarColor } from './special.js';
@@ -182,6 +182,7 @@
     raptorBias: 0.68,
     supplyEveryMinMax: [8, 16],
     worldMargin: 80,
+    scrollSpeed: 40,
     player: {
       radius: 16, speed: 240, maxHP: 100, invuln: 0.7,
       baseFireRate: 4, baseBulletDamage: 15, bulletSpeed: 540,
@@ -708,6 +709,13 @@
         for (const arr of [this.bullets, this.enemies, this.grenades, this.supplies, this.particles, this.meteors]) {
         for (const e of arr) e.update?.(dt, this);
       }
+
+      const scroll = CONFIG.scrollSpeed * dt;
+      this.player.pos.x -= scroll;
+      for (const arr of [this.bullets, this.enemies, this.grenades, this.supplies, this.particles, this.meteors]) {
+        for (const e of arr) e.pos.x -= scroll;
+      }
+      scrollScenery(this.scenery, canvas.clientWidth, canvas.clientHeight, CONFIG.scrollSpeed, dt);
 
       // Bullet -> Enemy
       for (const b of this.bullets) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elisgames",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
       "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js && node test/meteor.test.js",

--- a/scenery.js
+++ b/scenery.js
@@ -5,6 +5,10 @@ export class Scenery {
     this.type = type;
   }
 
+  update(dt, speed) {
+    this.x -= speed * dt;
+  }
+
   draw(ctx, sprites, drawSprite) {
     const sprite = sprites[this.type];
     if (sprite) {
@@ -23,4 +27,20 @@ export function generateScenery(count, width, height, rand = Math.random) {
     items.push(new Scenery(x, y, type));
   }
   return items;
+}
+
+export function scrollScenery(items, width, height, speed, dt, rand = Math.random) {
+  const types = ['tree', 'rock'];
+  for (const s of items) {
+    s.update(dt, speed);
+  }
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (items[i].x < -50) {
+      items.splice(i, 1);
+      const x = width + rand() * 50;
+      const y = rand() * height;
+      const type = types[Math.floor(rand() * types.length)];
+      items.push(new Scenery(x, y, type));
+    }
+  }
 }

--- a/test/scenery.test.js
+++ b/test/scenery.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { Scenery, generateScenery } from '../scenery.js';
+import { Scenery, generateScenery, scrollScenery } from '../scenery.js';
 
 // deterministic pseudo-random generator
 function makeRand(values) {
@@ -30,6 +30,18 @@ function makeRand(values) {
     assert.equal(y, 6);
   });
   assert.ok(called);
+}
+
+// Test scrollScenery moves and spawns items
+{
+  const rand = makeRand([0.2, 0.3, 0.8]);
+  const items = [new Scenery(10, 5, 'tree'), new Scenery(-60, 10, 'rock')];
+  scrollScenery(items, 100, 50, 20, 1, rand);
+  assert.equal(items.length, 2);
+  assert.deepEqual(items.map(i => [i.x, i.y, i.type]), [
+    [-10, 5, 'tree'],
+    [110, 15, 'rock']
+  ]);
 }
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Add scrolling support for scenery and entities
- Spawn new trees and rocks from the right side
- Switch grass background to dark green and bump version to 1.5

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af457eddf0832daa9c4179d18bc788