### PR TITLE
Implement smooth land-sea transition with scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -640,6 +640,8 @@
       this.player = new Player(canvas.clientWidth*0.5, canvas.clientHeight*0.6);
         this.bullets = []; this.enemies = []; this.grenades = []; this.supplies = []; this.particles = []; this.meteors = [];
       this.environment = 'land';
+      this.nextEnvironment = null;
+      this.transitionTimer = 0;
       this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, this.environment);
       this.day = 1; this.dayTimer = 0; this.bossAlive = false;
       this.enemySpawnCD = CONFIG.baseSpawnInterval; this.supplyCD = rand(...CONFIG.supplyEveryMinMax);
@@ -778,6 +780,13 @@
         for (const e of arr) e.pos.x -= scroll;
       }
       scrollScenery(this.scenery, canvas.clientWidth, canvas.clientHeight, CONFIG.scrollSpeed, dt, Math.random, this.environment);
+      if (this.environment === 'transition') {
+        this.transitionTimer -= dt;
+        if (this.transitionTimer <= 0) {
+          this.environment = this.nextEnvironment;
+          this.nextEnvironment = null;
+        }
+      }
 
       // Bullet -> Enemy
       for (const b of this.bullets) {
@@ -812,10 +821,13 @@
         if (!boss) {
           const prevEnv = this.environment;
           this.bossAlive = false; this.day++; this.dayTimer = 0; this.player.healToFull();
-          this.environment = Math.floor((this.day-1)/3)%2 === 0 ? 'land' : 'water';
-          if (this.environment !== prevEnv) {
-            this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, 'transition');
+          const newEnv = Math.floor((this.day-1)/3)%2 === 0 ? 'land' : 'water';
+          if (newEnv !== prevEnv) {
+            this.nextEnvironment = newEnv;
+            this.environment = 'transition';
+            this.transitionTimer = canvas.clientWidth / CONFIG.scrollSpeed;
           } else {
+            this.environment = newEnv;
             this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, this.environment);
           }
           showToast(`Day ${this.day} begins — tougher foes ahead.`, 'ok'); AudioBus.blip({freq: 860, dur:.08, vol:.16});

--- a/test/scenery.test.js
+++ b/test/scenery.test.js
@@ -69,4 +69,13 @@ function makeRand(values) {
   assert.deepEqual(items.map(i => i.type), ['beach', 'whitewash']);
 }
 
+// Test scrollScenery spawns items in transition environment
+{
+  const rand = makeRand([0.2, 0.3, 0.7]);
+  const items = [new Scenery(-60, 10, 'beach')];
+  scrollScenery(items, 100, 50, 20, 1, rand, 'transition');
+  assert.equal(items.length, 1);
+  assert.equal(items[0].type, 'whitewash');
+}
+
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Add transition environment state to scroll gradually between land and water
- Track upcoming environment and timer to finalize the switch
- Test scenery scrolling in transition environment

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7c4f92a8832da38c12e1ae5d1c72