### PR TITLE
Fix boss-death stutter and environment backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
   <div id="toast"></div>
 
   <script type="module">
-    import { Scenery, generateScenery, scrollScenery } from './scenery.js';
+    import { Scenery, generateScenery, scrollScenery, backgroundForEnv } from './scenery.js';
     import { createRaptorClass } from './raptor.js';
     import { createProjectileClasses } from './projectiles.js';
     import { createMeteorClass, specialBarColor } from './special.js';
@@ -840,6 +840,7 @@
 
     render(){
       const w = canvas.clientWidth, h = canvas.clientHeight;
+      canvas.style.background = backgroundForEnv(this.environment);
       ctx.clearRect(0,0,w,h);
       ctx.imageSmoothingEnabled = false;
 
@@ -934,8 +935,13 @@
   let last = now();
 
   function frame(){
-    const t = now(); let dt = (t - last) / 1000; dt = Math.min(dt, 1/20); last = t;
-    game.update(dt); game.render(); requestAnimationFrame(frame);
+    const t = now();
+    let dt = (t - last) / 1000;
+    dt = Math.min(dt, 1/20);
+    game.update(dt);
+    game.render();
+    last = now();
+    requestAnimationFrame(frame);
   }
   requestAnimationFrame(frame);
 

--- a/scenery.js
+++ b/scenery.js
@@ -52,3 +52,15 @@ export function scrollScenery(items, width, height, speed, dt, rand = Math.rando
     }
   }
 }
+
+export function backgroundForEnv(env = 'land') {
+  switch (env) {
+    case 'water':
+      return '#001a33';
+    case 'transition':
+      return '#704214';
+    case 'land':
+    default:
+      return '#002b11';
+  }
+}

--- a/test/scenery.test.js
+++ b/test/scenery.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { Scenery, generateScenery, scrollScenery } from '../scenery.js';
+import { Scenery, generateScenery, scrollScenery, backgroundForEnv } from '../scenery.js';
 
 // deterministic pseudo-random generator
 function makeRand(values) {
@@ -76,6 +76,13 @@ function makeRand(values) {
   scrollScenery(items, 100, 50, 20, 1, rand, 'transition');
   assert.equal(items.length, 1);
   assert.equal(items[0].type, 'whitewash');
+}
+
+// Test background colors for each environment
+{
+  assert.equal(backgroundForEnv('land'), '#002b11');
+  assert.equal(backgroundForEnv('water'), '#001a33');
+  assert.equal(backgroundForEnv('transition'), '#704214');
 }
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Smooth out post-boss scroll by measuring frame time after rendering
- Change canvas background by environment (land, water, beach)
- Add tests for environment background colors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9756c1c0832d9cb560548b8fa202