### PR TITLE
feat: revamp water dinos

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,15 +299,16 @@
   });
 
   // Water Dino (24x24)
+  // Serpentine water creature without feet
   Sprites.waterdino = makeSprite(24,24,(s)=>{
-    const body='#5ab4ff', belly='#bfe9ff';
-    s.fillStyle = body; s.fillRect(2,12,6,2); s.fillRect(6,11,4,4);
-    s.fillStyle = body; s.fillRect(9,9,9,8);
-    s.fillStyle = belly; s.fillRect(11,12,6,3);
-    s.fillStyle = body; s.fillRect(17,8,5,5);
-    px(s, 20,9,'#fff'); px(s, 20,10,'#fff'); px(s,21,10,'#000');
-    s.fillStyle = '#2a3c2f'; s.fillRect(11,17,3,3); s.fillRect(15,17,3,3);
-    s.fillStyle = '#eee'; px(s, 11,20,'#eee'); px(s, 16,20,'#eee');
+    const body='#5ab4ff', belly='#bfe9ff', fin='#3d94d9';
+    s.fillStyle = body; s.fillRect(2,12,20,4); // long body
+    s.fillRect(2,14,4,4); // tail curve
+    s.fillRect(16,8,4,4); // neck
+    s.fillRect(18,4,4,4); // head
+    s.fillStyle = belly; s.fillRect(4,13,12,2); // underside
+    s.fillStyle = fin; s.fillRect(8,8,4,4); // dorsal fin
+    px(s,19,5,'#fff'); px(s,20,5,'#000'); // eye
   });
 
   // Pterodactyl (24x24)
@@ -335,16 +336,16 @@
   });
 
   // Mosasaurus (48x48)
+  // Aquatic boss with long mouth, fins and tail
   Sprites.mosasaurus = makeSprite(48,48,(s)=>{
     const body='#5ab4ff', belly='#bfe9ff', dark='#103b5b';
-    s.fillStyle = body; s.fillRect(8,16,28,18);
-    s.fillStyle = belly; s.fillRect(14,22,16,6);
-    s.fillStyle = body; s.fillRect(30,12,12,12);
-    s.fillStyle = dark; s.fillRect(39,14,3,3);
-    s.fillStyle = dark; s.fillRect(30,18,12,4);
-    s.fillStyle = '#0b2a3d'; s.fillRect(16,32,6,6); s.fillRect(26,32,6,6);
-    s.fillStyle = '#e6f7ff'; s.fillRect(16,38,3,2); s.fillRect(29,38,3,2);
-    s.fillStyle = body; s.fillRect(2,20,8,6);
+    s.fillStyle = body; s.fillRect(4,20,34,10); // main body
+    s.fillRect(0,22,8,6); // tail
+    s.fillRect(38,18,10,6); // head and long mouth
+    s.fillStyle = dark; s.fillRect(42,19,6,2); // mouth line
+    s.fillStyle = belly; s.fillRect(8,24,26,4); // underside
+    s.fillStyle = body; s.fillRect(14,30,8,4); s.fillRect(26,30,8,4); // fins
+    s.fillStyle = '#fff'; s.fillRect(44,20,2,2); s.fillStyle='#000'; s.fillRect(45,20,1,1); // eye
   });
 
   // Bullet & Grenade

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.4.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-      "version": "1.4.0",
+      "version": "1.8.0",
       "devDependencies": {
         "eslint": "^8.57.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "elisgames",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
-      "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js && node test/meteor.test.js",
-      "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/grenade.test.js test/special.test.js test/meteor.test.js"
-    },
+    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js && node test/meteor.test.js && node test/water-sprites.test.js",
+    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/grenade.test.js test/special.test.js test/meteor.test.js test/water-sprites.test.js"
+  },
   "devDependencies": {
     "eslint": "^8.57.0"
   }

--- a/test/water-sprites.test.js
+++ b/test/water-sprites.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+function extractPainter(name) {
+  const text = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const startToken = `Sprites.${name} = makeSprite`;
+  const start = text.indexOf(startToken);
+  if (start === -1) throw new Error(`Sprite ${name} not found`);
+  const funcStart = text.indexOf('(s)=>{', start) + '(s)=>{'.length;
+  let i = funcStart, depth = 1;
+  while (depth > 0 && i < text.length) {
+    const ch = text[i++];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+  }
+  const body = text.slice(funcStart, i - 1);
+  // eslint-disable-next-line no-new-func
+  return new Function('s', 'px', body);
+}
+
+function recordRects(painter) {
+  const rects = [];
+  const ctx = {
+    fillStyle: null,
+    fillRect(x, y, w, h) {
+      rects.push({ x, y, w, h });
+    },
+    beginPath() {}, moveTo() {}, lineTo() {}, closePath() {}, fill() {}, stroke() {}, arc() {},
+    strokeStyle: null, lineWidth: null
+  };
+  const px = (c, x, y, color) => { c.fillStyle = color; c.fillRect(x, y, 1, 1); };
+  painter(ctx, px);
+  return rects;
+}
+
+function hasRect(rects, x, y, w, h) {
+  return rects.some(r => r.x === x && r.y === y && r.w === w && r.h === h);
+}
+
+// Water dino should not have feet rectangles
+{
+  const painter = extractPainter('waterdino');
+  const rects = recordRects(painter);
+  assert.ok(!hasRect(rects, 11, 17, 3, 3));
+  assert.ok(!hasRect(rects, 15, 17, 3, 3));
+  assert.ok(!hasRect(rects, 11, 20, 1, 1));
+  assert.ok(!hasRect(rects, 16, 20, 1, 1));
+}
+
+// Mosasaurus boss should not have foot rectangles
+{
+  const painter = extractPainter('mosasaurus');
+  const rects = recordRects(painter);
+  assert.ok(!hasRect(rects, 16, 32, 6, 6));
+  assert.ok(!hasRect(rects, 26, 32, 6, 6));
+  assert.ok(!hasRect(rects, 16, 38, 3, 2));
+  assert.ok(!hasRect(rects, 29, 38, 3, 2));
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- make water dino serpentine without feet
- draw mosasaurus boss with long mouth, fins and tail
- add tests ensuring no foot pixels on water creatures
- bump to version 1.8.0

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9f4b4f3c832d8bc6151418f59c87