### PR TITLE
Fix boss stutter and canvas background

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@
       this.nextEnvironment = null;
       this.transitionTimer = 0;
       this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, this.environment);
-      this.day = 1; this.dayTimer = 0; this.bossAlive = false;
+      this.day = 1; this.dayTimer = 0; this.bossAlive = false; this.boss = null;
       this.enemySpawnCD = CONFIG.baseSpawnInterval; this.supplyCD = rand(...CONFIG.supplyEveryMinMax);
       this.highScore = Number(localStorage.getItem('dino_highscore') || 0);
       this.kills = 0; this.score = 0;
@@ -724,13 +724,16 @@
       else if (side==='left'){ x=-m; y=rand(m, h-m); }
       else { x=w+m; y=rand(m, h-m); }
       const d = this.difficultyForDay(this.day), base = CONFIG.enemies.trex;
+      let boss;
       if (this.environment === 'water') {
-        this.enemies.push(new Mosasaurus(x,y, rand(...base.speed)*d.speed, Math.ceil(base.hp*d.hp), Math.ceil(base.dmg*d.dmg)));
+        boss = new Mosasaurus(x,y, rand(...base.speed)*d.speed, Math.ceil(base.hp*d.hp), Math.ceil(base.dmg*d.dmg));
         showToast(`Day ${this.day} Boss: Mosasaurus`, 'danger');
       } else {
-        this.enemies.push(new TRex(x,y, rand(...base.speed)*d.speed, Math.ceil(base.hp*d.hp), Math.ceil(base.dmg*d.dmg)));
+        boss = new TRex(x,y, rand(...base.speed)*d.speed, Math.ceil(base.hp*d.hp), Math.ceil(base.dmg*d.dmg));
         showToast(`Day ${this.day} Boss: T‑Rex`, 'danger');
       }
+      this.enemies.push(boss);
+      this.boss = boss;
       this.bossAlive = true; AudioBus.roar();
     }
 
@@ -817,22 +820,19 @@
         this.meteors = this.meteors.filter(e => e.alive);
 
       // Boss lifecycle
-      if (this.bossAlive) {
-        const boss = this.enemies.find(e => e.isBoss);
-        if (!boss) {
-          const prevEnv = this.environment;
-          this.bossAlive = false; this.day++; this.dayTimer = 0; this.player.healToFull();
-          const newEnv = Math.floor((this.day-1)/3)%2 === 0 ? 'land' : 'water';
-          if (newEnv !== prevEnv) {
-            this.nextEnvironment = newEnv;
-            this.environment = 'transition';
-            this.transitionTimer = canvas.clientWidth / CONFIG.scrollSpeed;
-          } else {
-            this.environment = newEnv;
-            this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, this.environment);
-          }
-          showToast(`Day ${this.day} begins — tougher foes ahead.`, 'ok'); AudioBus.blip({freq: 860, dur:.08, vol:.16});
+      if (this.bossAlive && (!this.boss || !this.boss.alive)) {
+        const prevEnv = this.environment;
+        this.bossAlive = false; this.boss = null; this.day++; this.dayTimer = 0; this.player.healToFull();
+        const newEnv = Math.floor((this.day-1)/3)%2 === 0 ? 'land' : 'water';
+        if (newEnv !== prevEnv) {
+          this.nextEnvironment = newEnv;
+          this.environment = 'transition';
+          this.transitionTimer = canvas.clientWidth / CONFIG.scrollSpeed;
+        } else {
+          this.environment = newEnv;
+          this.scenery = generateScenery(40, canvas.clientWidth, canvas.clientHeight, this.environment);
         }
+        showToast(`Day ${this.day} begins — tougher foes ahead.`, 'ok'); AudioBus.blip({freq: 860, dur:.08, vol:.16});
       }
 
       this.score += dt * (2 * this.day);
@@ -841,8 +841,10 @@
 
     render(){
       const w = canvas.clientWidth, h = canvas.clientHeight;
-      canvas.style.background = backgroundForEnv(this.environment);
-      ctx.clearRect(0,0,w,h);
+      const bg = backgroundForEnv(this.environment);
+      if (canvas.style.background !== bg) canvas.style.background = bg;
+      ctx.fillStyle = bg;
+      ctx.fillRect(0,0,w,h);
       ctx.imageSmoothingEnabled = false;
 
       // subtle grid
@@ -861,7 +863,7 @@
         this.player.draw(ctx, this);
         for (const p of this.particles) p.draw(ctx, this);
 
-      const boss = this.enemies.find(e => e.isBoss);
+      const boss = this.boss;
       const bossRow = document.getElementById('bossRow');
       if (boss) {
         bossRow.style.display = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "devDependencies": {
         "eslint": "^8.57.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "elisgames",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
-    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js && node test/meteor.test.js && node test/water-sprites.test.js",
-    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/grenade.test.js test/special.test.js test/meteor.test.js test/water-sprites.test.js"
+    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/grenade.test.js && node test/special.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js",
+    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/grenade.test.js test/special.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/test/background.test.js
+++ b/test/background.test.js
@@ -1,0 +1,7 @@
+import assert from 'assert';
+import { backgroundForEnv } from '../scenery.js';
+
+assert.strictEqual(backgroundForEnv('land'), '#002b11');
+assert.strictEqual(backgroundForEnv('water'), '#001a33');
+assert.strictEqual(backgroundForEnv('transition'), '#704214');
+console.log('backgroundForEnv returns expected colors');


### PR DESCRIPTION
## Summary
- track boss entity to avoid stutter after its death
- fill canvas with environment color to prevent black background
- add background color test and bump version to 1.8.1

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afab982004832dac69f6ff4cf55934