### PR TITLE
Add shotgun crate sprite and expand special attack

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,6 +364,11 @@
     s.strokeStyle='#203049'; s.lineWidth=2; s.strokeRect(1,1,12,12);
     s.fillStyle='#64d2ff'; s.fillRect(3,6,8,2); s.fillRect(8,4,3,6);
   });
+  Sprites.crateShot = makeSprite(14,14,(s)=>{
+    s.fillStyle='#101824'; s.fillRect(0,0,14,14);
+    s.strokeStyle='#203049'; s.lineWidth=2; s.strokeRect(1,1,12,12);
+    s.fillStyle='#ff64d2'; s.fillRect(3,6,8,2); s.fillRect(8,4,3,6);
+  });
 
   Sprites.grass = makeSprite(12,6,(s)=>{
     s.fillStyle='#1e5d2b'; s.fillRect(0,3,12,3);
@@ -551,9 +556,9 @@
     update(dt){ this.pulse += dt*2.2; }
     draw(ctx){
       const glow = (Math.sin(this.pulse)*0.5 + 0.5)*6 + 8;
-      ctx.save(); ctx.globalAlpha = .18; ctx.fillStyle = this.type==='grenade' ? '#ffe59a' : '#a8d5ff';
+      ctx.save(); ctx.globalAlpha = .18; ctx.fillStyle = this.type==='grenade' ? '#ffe59a' : this.type==='shotgun' ? '#ffa8e2' : '#a8d5ff';
       ctx.beginPath(); ctx.arc(this.pos.x, this.pos.y, this.radius+glow, 0, Math.PI*2); ctx.fill(); ctx.restore();
-      drawSprite(this.type==='grenade'?Sprites.crateGren:Sprites.crateGun, this.pos.x, this.pos.y, 0, 1.6);
+      drawSprite(this.type==='grenade'?Sprites.crateGren:this.type==='shotgun'?Sprites.crateShot:Sprites.crateGun, this.pos.x, this.pos.y, 0, 1.6);
     }
   }
 
@@ -707,7 +712,7 @@
     }
     onKill(e, fromSpecial=false){
       this.kills++; this.score += 10 * (e.isBoss ? 30 : 1) * this.day;
-      if (!fromSpecial) this.specialCharge = Math.min(20, this.specialCharge + 1);
+      if (!fromSpecial) this.specialCharge = Math.min(30, this.specialCharge + 1);
       if (!e.isBoss && Math.random()<0.08) this.dropSupply(e.pos.x, e.pos.y);
       const color = e.isBoss ? '#ffd0d0' : (e instanceof Pterodactyl ? '#9de0ff' : '#6fe27e');
       for (let i=0;i<14;i++) this.particles.push(new Particle(e.pos.x, e.pos.y,
@@ -718,7 +723,9 @@
         for (let i=0;i<5;i++) this.meteors.push(new Meteor(rand(0, w)));
         const x=this.player.pos.x, y=this.player.pos.y;
         for (const e of this.enemies) {
-          if (!e.alive) continue; e.damage(9999); if (!e.alive) this.onKill(e, true);
+          if (!e.alive || e.isBoss) continue;
+          e.damage(9999);
+          if (!e.alive) this.onKill(e, true);
         }
       for (let i=0;i<36;i++) this.particles.push(new Particle(x,y, Vec2.fromAngle(i/36*Math.PI*2, 280), .4, '#ff7bff', 2));
       AudioBus.boom({freq:120, dur:.2, vol:.3});
@@ -809,7 +816,7 @@
       this.player.update(dt, this);
       if (Input.special) {
         Input.special = false;
-        if (this.specialCharge >= 20 && !this.specialActive) {
+        if (this.specialCharge >= 30 && !this.specialActive) {
           this.specialActive = true; this.specialTimer = 5; this.specialPulseTimer = 0; this.specialCharge = 0;
         }
       }
@@ -967,7 +974,7 @@
       timeleft.textContent = game.bossAlive ? 'Boss!' : `${Math.max(0, Math.ceil(CONFIG.dayLength - game.dayTimer))}s`;
       hpbar.style.width = `${clamp(game.player.hp / game.player.maxHP, 0, 1) * 100}%`;
       hptext.textContent = Math.max(0, Math.ceil(game.player.hp));
-      spbar.style.width = `${clamp(game.specialCharge / 20, 0, 1) * 100}%`;
+      spbar.style.width = `${clamp(game.specialCharge / 30, 0, 1) * 100}%`;
       spbar.style.background = specialBarColor(game.specialCharge);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "devDependencies": {
         "eslint": "^8.57.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "elisgames",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
-    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js",
-    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js"
+    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js",
+    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/special-boss.test.js test/crate-sprite.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/special.js
+++ b/special.js
@@ -1,5 +1,5 @@
 export function specialBarColor(charge) {
-  return charge >= 20
+  return charge >= 30
     ? 'linear-gradient(90deg, var(--accent-2), #b2ff9f)'
     : 'linear-gradient(90deg, var(--accent), #9df3ff)';
 }

--- a/test/crate-sprite.test.js
+++ b/test/crate-sprite.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+
+const Sprites = { crateGren:{}, crateGun:{}, crateShot:{} };
+let lastSprite = null;
+function drawSprite(sprite){ lastSprite = sprite; }
+
+class Supply {
+  constructor(type){ this.type = type; this.pos = {x:0,y:0}; this.radius = 14; this.pulse = 0; }
+  draw(ctx){
+    const glow = (Math.sin(this.pulse)*0.5 + 0.5)*6 + 8;
+    ctx.save(); ctx.globalAlpha = .18; ctx.fillStyle = this.type==='grenade' ? '#ffe59a' : this.type==='shotgun' ? '#ffa8e2' : '#a8d5ff';
+    ctx.beginPath(); ctx.arc(this.pos.x, this.pos.y, this.radius+glow, 0, Math.PI*2); ctx.fill(); ctx.restore();
+    drawSprite(this.type==='grenade'?Sprites.crateGren:this.type==='shotgun'?Sprites.crateShot:Sprites.crateGun, this.pos.x, this.pos.y, 0, 1.6);
+  }
+}
+
+const ctx = { save(){}, restore(){}, beginPath(){}, arc(){}, fill(){}, globalAlpha:0, fillStyle:'' };
+const machine = new Supply('machine');
+machine.draw(ctx);
+assert.equal(lastSprite, Sprites.crateGun);
+const shot = new Supply('shotgun');
+shot.draw(ctx);
+assert.equal(lastSprite, Sprites.crateShot);
+console.log('Crate sprite test passed');

--- a/test/meteor.test.js
+++ b/test/meteor.test.js
@@ -27,6 +27,6 @@ for(let i=0;i<5;i++) m.update(0.1, game);
 assert.ok(game.explodeCalled > 0);
 
 assert.equal(specialBarColor(10), 'linear-gradient(90deg, var(--accent), #9df3ff)');
-assert.equal(specialBarColor(20), 'linear-gradient(90deg, var(--accent-2), #b2ff9f)');
+assert.equal(specialBarColor(30), 'linear-gradient(90deg, var(--accent-2), #b2ff9f)');
 
 console.log('Meteor and special gauge tests passed');

--- a/test/special-boss.test.js
+++ b/test/special-boss.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+
+class Dino {
+  constructor(isBoss){ this.isBoss = isBoss; this.alive = true; }
+  damage(){ this.alive = false; }
+}
+
+class Game {
+  constructor(){
+    this.enemies = [new Dino(false), new Dino(true)];
+    this.meteors = [];
+    this.particles = [];
+    this.player = { pos: { x: 0, y: 0 } };
+  }
+  laserBlast(){
+    for(let i=0;i<5;i++) this.meteors.push(i);
+    for(const e of this.enemies){
+      if(!e.alive || e.isBoss) continue;
+      e.damage(9999);
+    }
+  }
+}
+
+const g = new Game();
+g.laserBlast();
+assert.equal(g.enemies[0].alive, false);
+assert.equal(g.enemies[1].alive, true);
+console.log('Special boss immunity test passed');

--- a/test/special-kill.test.js
+++ b/test/special-kill.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 
 class Game {
   constructor(){ this.specialCharge=0; }
-  onKill(fromSpecial=false){ if(!fromSpecial) this.specialCharge=Math.min(20,this.specialCharge+1); }
+  onKill(fromSpecial=false){ if(!fromSpecial) this.specialCharge=Math.min(30,this.specialCharge+1); }
 }
 
 const g=new Game();

--- a/test/special.test.js
+++ b/test/special.test.js
@@ -4,7 +4,7 @@ const Input = { special:false };
 let pulses = 0;
 class Game {
   constructor(){
-    this.specialCharge = 20;
+    this.specialCharge = 30;
     this.specialActive = false;
     this.specialTimer = 0;
     this.specialPulseTimer = 0;
@@ -13,7 +13,7 @@ class Game {
   update(dt){
     if (Input.special) {
       Input.special = false;
-      if (this.specialCharge >= 20 && !this.specialActive) {
+      if (this.specialCharge >= 30 && !this.specialActive) {
         this.specialActive = true; this.specialTimer = 5; this.specialPulseTimer = 0; this.specialCharge = 0;
       }
     }


### PR DESCRIPTION
## Summary
- Add distinct shotgun crate sprite and glow to differentiate from machine gun crates
- Extend special attack to charge to 30, sparing boss dinos
- Bump version to 1.11.0 and add tests for crates and boss immunity

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afef53f0a0832d9e12022a38ed43e1