### PR TITLE
Add shotgun HUD and dot bullets

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
       <span class="pill">Score <b id="score">0</b></span>
       <span class="pill">Grenades <b id="grenades">1</b></span>
       <span class="pill">Machine Lvl <b id="machlvl">1</b></span>
+      <span class="pill">Shotgun Lvl <b id="shotlvl">1</b></span>
     </div>
     <div class="row" title="Time until boss">
       <div class="bar" style="width:260px"><i id="daybar"></i></div>
@@ -124,6 +125,7 @@
           <ul>
             <li><b>Grenade Crate:</b> +1–2 grenades.</li>
             <li><b>Gun Upgrade:</b> faster fire &amp; more damage (max 5).</li>
+            <li><b>Shotgun Upgrade:</b> more pellets (max 10).</li>
           </ul>
         </div>
       </div>
@@ -349,7 +351,7 @@
   });
 
   // Bullet & Grenade
-  Sprites.bullet = makeSprite(6,2,(s)=>{ s.fillStyle='#e8f5ff'; s.fillRect(0,0,6,2); });
+  Sprites.bullet = makeSprite(4,4,(s)=>{ s.fillStyle='#e8f5ff'; s.beginPath(); s.arc(2,2,2,0,Math.PI*2); s.fill(); });
   Sprites.grenade = makeSprite(8,8,(s)=>{
     s.fillStyle = '#8a6b2c'; s.fillRect(2,1,2,2);
     s.fillStyle = '#ffd36b'; s.fillRect(1,3,6,4);
@@ -937,18 +939,16 @@
   }
 
   Bullet.prototype.draw = function(ctx){
+    ctx.save();
+    ctx.fillStyle = this.color || '#e8f5ff';
     if (this.color) {
-      ctx.save();
-      ctx.fillStyle = this.color;
       ctx.shadowColor = this.color;
       ctx.shadowBlur = 8;
-      ctx.beginPath();
-      ctx.arc(this.pos.x, this.pos.y, this.radius, 0, Math.PI*2);
-      ctx.fill();
-      ctx.restore();
-    } else {
-      drawSprite(Sprites.bullet, this.pos.x, this.pos.y, this.ang, this.radius*0.375);
     }
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, this.radius, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
   };
   Missile.prototype.draw = function(ctx){ drawSprite(Sprites.bullet, this.pos.x, this.pos.y, this.ang, this.radius*0.5); };
 
@@ -958,6 +958,7 @@
   const score     = document.getElementById('score');
   const grenades  = document.getElementById('grenades');
   const machlvl   = document.getElementById('machlvl');
+  const shotlvl   = document.getElementById('shotlvl');
   const daybar    = document.getElementById('daybar');
   const timeleft  = document.getElementById('timeleft');
     const hpbar     = document.getElementById('hpbar');
@@ -970,6 +971,7 @@
     score.textContent = Math.floor(game.score);
     grenades.textContent = game.player.grenades;
     machlvl.textContent = game.player.machineLevel;
+    shotlvl.textContent = game.player.shotgunLevel;
       daybar.style.width = `${clamp(game.dayTimer / CONFIG.dayLength, 0, 1) * 100}%`;
       timeleft.textContent = game.bossAlive ? 'Boss!' : `${Math.max(0, Math.ceil(CONFIG.dayLength - game.dayTimer))}s`;
       hpbar.style.width = `${clamp(game.player.hp / game.player.maxHP, 0, 1) * 100}%`;

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.11.0",
   "type": "module",
   "scripts": {
-    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js",
-    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/special-boss.test.js test/crate-sprite.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js"
+    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js && node test/bullet-draw.test.js && node test/hud-shotgun.test.js",
+    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/special-boss.test.js test/crate-sprite.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js test/bullet-draw.test.js test/hud-shotgun.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/test/bullet-draw.test.js
+++ b/test/bullet-draw.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+
+class Bullet {
+  constructor(x, y, radius = 4, color = null) {
+    this.pos = { x, y };
+    this.radius = radius;
+    this.color = color;
+  }
+  draw(ctx) {
+    ctx.save();
+    ctx.fillStyle = this.color || '#e8f5ff';
+    ctx.beginPath();
+    ctx.arc(this.pos.x, this.pos.y, this.radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+const calls = { save: 0, restore: 0, arc: [] };
+const ctx = {
+  save() { calls.save++; },
+  restore() { calls.restore++; },
+  beginPath() {},
+  arc(x, y, r) { calls.arc = [x, y, r]; },
+  fill() {},
+  set fillStyle(v) { calls.fillStyle = v; },
+  get fillStyle() { return calls.fillStyle; }
+};
+
+const b = new Bullet(10, 20);
+b.draw(ctx);
+
+assert.deepEqual(calls.arc, [10, 20, 4]);
+assert.equal(calls.fillStyle, '#e8f5ff');
+assert.equal(calls.save, 1);
+assert.equal(calls.restore, 1);
+
+console.log('Bullet draw test passed');
+

--- a/test/hud-shotgun.test.js
+++ b/test/hud-shotgun.test.js
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+assert.ok(
+  html.includes('Shotgun Lvl <b id="shotlvl">1</b>'),
+  'HUD should display shotgun level'
+);
+
+console.log('HUD shotgun test passed');
+


### PR DESCRIPTION
## Summary
- Render bullets as circular dots and keep color glow
- Display shotgun level in HUD and list shotgun upgrade in supplies panel
- Add tests for bullet drawing and shotgun HUD entry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b00ae64894832da3011c4f232bd388