### PR TITLE
Boost missile speed and boss difficulty

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,9 +507,11 @@
     }
     shootMissile(game){
       if (this.missileLevel <= 0) return;
-      const vel = Vec2.fromAngle(this.aim.angle(), CONFIG.player.bulletSpeed*0.9);
+      const level = this.missileLevel;
+      const speed = CONFIG.player.bulletSpeed * (0.9 + 0.03 * (level - 1));
+      const vel = Vec2.fromAngle(this.aim.angle(), speed);
       const opts = { missile:true };
-      if (this.missileLevel === 10) { opts.explosive = true; opts.glow = true; }
+      if (level === 10) { opts.explosive = true; opts.glow = true; }
       game.spawnBullet(this.pos.x + this.aim.x*this.radius, this.pos.y + this.aim.y*this.radius, vel, this.bulletDamage*2, this.aim.angle(), opts);
       AudioBus.blip({freq: 300, dur:.08, vol:.2});
     }
@@ -771,10 +773,20 @@
       } else this.bullets.push(new Bullet(x,y, vel, dmg, ang, opts.life, opts.radius, opts.color, opts.stun));
     }
 
-    difficultyForDay(day){
+    difficultyForDay(day, isBoss=false){
       const m = CONFIG.difficultyPerDay, n = day - 1;
-      return { hp: Math.pow(m.hp, n), speed: Math.pow(m.speed, n), dmg: Math.pow(m.dmg, n),
-               spawnInterval: CONFIG.baseSpawnInterval / Math.pow(m.spawnRate, n) };
+      const scale = {
+        hp: Math.pow(m.hp, n),
+        speed: Math.pow(m.speed, n),
+        dmg: Math.pow(m.dmg, n),
+        spawnInterval: CONFIG.baseSpawnInterval / Math.pow(m.spawnRate, n)
+      };
+      if (isBoss) {
+        const bossFactor = Math.pow(1.2, n);
+        scale.hp *= bossFactor;
+        scale.dmg *= bossFactor;
+      }
+      return scale;
     }
 
     spawnEnemy(){
@@ -806,7 +818,7 @@
       else if (side==='bottom'){ x=rand(m, w-m); y=h+m; }
       else if (side==='left'){ x=-m; y=rand(m, h-m); }
       else { x=w+m; y=rand(m, h-m); }
-      const d = this.difficultyForDay(this.day), base = CONFIG.enemies.trex;
+      const d = this.difficultyForDay(this.day, true), base = CONFIG.enemies.trex;
       let boss;
       if (this.environment === 'water') {
         boss = new Mosasaurus(x,y, rand(...base.speed)*d.speed, Math.ceil(base.hp*d.hp), Math.ceil(base.dmg*d.dmg));
@@ -985,14 +997,10 @@
     ctx.restore();
   };
   Missile.prototype.draw = function(ctx){
-    if (this.glow) {
-      ctx.save(); ctx.globalAlpha = .6; ctx.fillStyle = '#00ff00';
-      ctx.beginPath(); ctx.arc(this.pos.x, this.pos.y, this.radius+4, 0, Math.PI*2); ctx.fill(); ctx.restore();
-    }
     ctx.save();
     ctx.translate(this.pos.x, this.pos.y);
     ctx.rotate(this.ang);
-    ctx.fillStyle = '#e8f5ff';
+    ctx.fillStyle = this.glow ? '#00ff00' : '#e8f5ff';
     ctx.beginPath();
     ctx.moveTo(-this.radius, -this.radius/2);
     ctx.lineTo(this.radius, -this.radius/2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-    "version": "1.13.0",
+      "version": "1.14.0",
       "devDependencies": {
         "eslint": "^8.57.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "elisgames",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
-    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js && node test/bullet-draw.test.js && node test/hud-shotgun.test.js && node test/hud-missile.test.js && node test/missile-draw.test.js && node test/shotgun-fire.test.js && node test/missile.test.js && node test/player-hit.test.js",
-    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/special-boss.test.js test/crate-sprite.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js test/bullet-draw.test.js test/hud-shotgun.test.js test/hud-missile.test.js test/missile-draw.test.js test/shotgun-fire.test.js test/missile.test.js test/player-hit.test.js"
+    "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js && node test/bullet-draw.test.js && node test/hud-shotgun.test.js && node test/hud-missile.test.js && node test/missile-draw.test.js && node test/shotgun-fire.test.js && node test/missile.test.js && node test/player-hit.test.js && node test/boss-difficulty.test.js",
+    "lint": "eslint audio.js scenery.js raptor.js projectiles.js special.js test/audio.test.js test/scenery.test.js test/raptor.test.js test/projectiles.test.js test/player.test.js test/shotgun.test.js test/grenade.test.js test/special.test.js test/special-kill.test.js test/special-boss.test.js test/crate-sprite.test.js test/meteor.test.js test/water-sprites.test.js test/background.test.js test/bullet-draw.test.js test/hud-shotgun.test.js test/hud-missile.test.js test/missile-draw.test.js test/shotgun-fire.test.js test/missile.test.js test/player-hit.test.js test/boss-difficulty.test.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0"

--- a/test/boss-difficulty.test.js
+++ b/test/boss-difficulty.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+
+const CONFIG = { baseSpawnInterval: 1.6, difficultyPerDay: { hp: 1.18, speed: 1.10, dmg: 1.12, spawnRate: 1.14 } };
+
+function difficultyForDay(day, isBoss=false){
+  const m = CONFIG.difficultyPerDay, n = day - 1;
+  const scale = {
+    hp: Math.pow(m.hp, n),
+    speed: Math.pow(m.speed, n),
+    dmg: Math.pow(m.dmg, n),
+    spawnInterval: CONFIG.baseSpawnInterval / Math.pow(m.spawnRate, n)
+  };
+  if (isBoss){
+    const bossFactor = Math.pow(1.2, n);
+    scale.hp *= bossFactor;
+    scale.dmg *= bossFactor;
+  }
+  return scale;
+}
+
+const d3Boss = difficultyForDay(3, true);
+const d3 = difficultyForDay(3);
+assert(d3Boss.hp > d3.hp);
+assert(d3Boss.dmg > d3.dmg);
+
+const d5Boss = difficultyForDay(5, true);
+const d5 = difficultyForDay(5);
+const ratio3 = d3Boss.hp / d3.hp;
+const ratio5 = d5Boss.hp / d5.hp;
+assert(ratio5 > ratio3);
+
+console.log('Boss difficulty scaling test passed');

--- a/test/missile-draw.test.js
+++ b/test/missile-draw.test.js
@@ -8,14 +8,10 @@ class Missile {
     this.glow = false;
   }
   draw(ctx) {
-    if (this.glow) {
-      ctx.save(); ctx.globalAlpha = .6; ctx.fillStyle = '#00ff00';
-      ctx.beginPath(); ctx.arc(this.pos.x, this.pos.y, this.radius + 4, 0, Math.PI * 2); ctx.fill(); ctx.restore();
-    }
     ctx.save();
     ctx.translate(this.pos.x, this.pos.y);
     ctx.rotate(this.ang);
-    ctx.fillStyle = '#e8f5ff';
+    ctx.fillStyle = this.glow ? '#00ff00' : '#e8f5ff';
     ctx.beginPath();
     ctx.moveTo(-this.radius, -this.radius / 2);
     ctx.lineTo(this.radius, -this.radius / 2);
@@ -60,6 +56,31 @@ assert.deepEqual(calls, [
   'fill',
   'restore'
 ]);
+
+const calls2 = [];
+const ctx2 = {
+  save() { calls2.push('save'); },
+  restore() { calls2.push('restore'); },
+  translate(x, y) { calls2.push(['translate', x, y]); },
+  rotate(a) { calls2.push(['rotate', a]); },
+  beginPath() { calls2.push('beginPath'); },
+  moveTo(x, y) { calls2.push(['moveTo', x, y]); },
+  lineTo(x, y) { calls2.push(['lineTo', x, y]); },
+  arc(x, y, r, a0, a1) { calls2.push(['arc', x, y, r, a0, a1]); },
+  closePath() { calls2.push('closePath'); },
+  fill() { calls2.push('fill'); },
+  set fillStyle(v) { calls2.push(['fillStyle', v]); },
+  get fillStyle() { return calls2.find(c => c[0] === 'fillStyle')?.[1]; }
+};
+
+const m2 = new Missile(5, 5);
+m2.glow = true;
+m2.draw(ctx2);
+
+assert.equal(calls2[3][1], '#00ff00');
+const arcCalls = calls2.filter(c => Array.isArray(c) && c[0] === 'arc');
+assert.equal(arcCalls.length, 1);
+assert.equal(arcCalls[0][3], 3);
 
 console.log('Missile draw test passed');
 

--- a/test/missile.test.js
+++ b/test/missile.test.js
@@ -5,13 +5,14 @@ class Vec2 {
   add(v){ this.x+=v.x; this.y+=v.y; return this; }
   scale(s){ this.x*=s; this.y*=s; return this; }
   copy(){ return new Vec2(this.x,this.y); }
+  len(){ return Math.hypot(this.x,this.y); }
   static fromAngle(a,mag=1){ return new Vec2(Math.cos(a)*mag, Math.sin(a)*mag); }
 }
 const CONFIG = { player:{ bulletSpeed:10, grenadeRadius:120, grenadeDamage:140 } };
 class Player{
   constructor(){ this.pos=new Vec2(0,0); this.aim=new Vec2(1,0); this.radius=16; this.bulletDamage=10; this.missileLevel=0; this.missileCD=0; }
   get missileCooldown(){ return [0,10,9,8,7,6,5,4,3,2,2][this.missileLevel]; }
-  shootMissile(game){ if(this.missileLevel<=0) return; const vel=Vec2.fromAngle(0,CONFIG.player.bulletSpeed*0.9); const opts={missile:true}; if(this.missileLevel===10){ opts.explosive=true; opts.glow=true; } game.spawnBullet(0,0,vel,this.bulletDamage*2,0,opts); }
+  shootMissile(game){ if(this.missileLevel<=0) return; const speed=CONFIG.player.bulletSpeed*(0.9+0.03*(this.missileLevel-1)); const vel=Vec2.fromAngle(0,speed); const opts={missile:true}; if(this.missileLevel===10){ opts.explosive=true; opts.glow=true; } game.spawnBullet(0,0,vel,this.bulletDamage*2,0,opts); }
   update(game,dt){ this.missileCD-=dt; if(this.missileLevel>0 && this.missileCD<=0){ this.missileCD=this.missileCooldown; this.shootMissile(game); } }
 }
 class Game{ constructor(){ this.bullets=[]; } spawnBullet(x,y,vel,dmg,ang,opts){ this.bullets.push({vel,dmg,opts}); } }
@@ -24,6 +25,7 @@ assert.equal(p.missileCD,0);
 p.missileLevel=1; p.update(game,0);
 assert.equal(game.bullets.length,1);
 assert.equal(p.missileCD,10);
+assert.equal(game.bullets[0].vel.len(), CONFIG.player.bulletSpeed*0.9);
 
 p.missileLevel=7; p.missileCD=0; p.update(game,0);
 assert.equal(p.missileCD,4);
@@ -32,5 +34,6 @@ p.missileLevel=10; p.missileCD=0; p.update(game,0);
 assert.equal(p.missileCD,2);
 assert.equal(game.bullets[2].opts.explosive,true);
 assert.equal(game.bullets[2].opts.glow,true);
+assert.equal(game.bullets[2].vel.len(), CONFIG.player.bulletSpeed*(0.9+0.03*9));
 
 console.log('Missile tests passed');


### PR DESCRIPTION
## Summary
- Scale missile velocity with level and make max-level missiles green instead of glowing
- Increase boss toughness more sharply with advancing days
- Add tests for missile speed, drawing, and boss difficulty; bump version to 1.14.0

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c35ea294832db61ee0da328480c8