### PR TITLE
fix: resolve three module import in browser

### DIFF
--- a/renderer3d.js
+++ b/renderer3d.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from './node_modules/three/build/three.module.js';
 
 export class Renderer3D {
   constructor(canvas) {

--- a/test/renderer3d.test.js
+++ b/test/renderer3d.test.js
@@ -1,5 +1,5 @@
 import { Renderer3D } from '../renderer3d.js';
-import * as THREE from 'three';
+import * as THREE from '../node_modules/three/build/three.module.js';
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg);


### PR DESCRIPTION
## Summary
- import three.js via relative path to avoid bare-module resolution error in browsers
- adjust renderer3d test to match new three.js import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb13aefcc0832daa6e8d1d74585a3c