### PR TITLE
Load three.js from CDN for browser builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,13 @@
     .toast.danger { border-left-color: var(--danger); }
     .footnote { color:#8aa2c0; font-size:12px; }
   </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.164.0/build/three.module.js"
+      }
+    }
+  </script>
 </head>
 <body>
   <canvas id="game"></canvas>

--- a/renderer3d.js
+++ b/renderer3d.js
@@ -1,4 +1,4 @@
-import * as THREE from './node_modules/three/build/three.module.js';
+import * as THREE from 'three';
 
 export class Renderer3D {
   constructor(canvas) {

--- a/test/renderer3d.test.js
+++ b/test/renderer3d.test.js
@@ -1,5 +1,5 @@
 import { Renderer3D } from '../renderer3d.js';
-import * as THREE from '../node_modules/three/build/three.module.js';
+import * as THREE from 'three';
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg);


### PR DESCRIPTION
## Summary
- Serve three.js via import map so the HTML file stands alone
- Import three from the package in renderer and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb15f71018832d9008c2adfef61706