### PR TITLE
feat: restore 2D sprites in 3D renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,6 +363,7 @@
     s.fillStyle = '#8a6b2c'; s.fillRect(2,1,2,2);
     s.fillStyle = '#ffd36b'; s.fillRect(1,3,6,4);
   });
+  Sprites.meteor = makeSprite(24,24,(s)=>{ s.fillStyle='#ff944d'; s.beginPath(); s.arc(12,12,12,0,Math.PI*2); s.fill(); });
   Sprites.crateGren = makeSprite(14,14,(s)=>{
     s.fillStyle='#101824'; s.fillRect(0,0,14,14);
     s.strokeStyle='#203049'; s.lineWidth=2; s.strokeRect(1,1,12,12);
@@ -951,14 +952,42 @@
       const bg = backgroundForEnv(this.environment);
       if (renderer3D.renderer) renderer3D.renderer.setClearColor(bg);
       renderer3D.clear();
-      this.scenery.forEach((d,i)=>renderer3D.addBlock(`scenery${i}`, d.x, d.y, 0x228B22, 20));
-      this.supplies.forEach((s,i)=>renderer3D.addBlock(`supply${i}`, s.pos.x, s.pos.y, 0xffff00, 20));
-      this.grenades.forEach((gr,i)=>renderer3D.addBlock(`grenade${i}`, gr.pos.x, gr.pos.y, 0xffaa00, gr.radius*2));
-      this.bullets.forEach((b,i)=>renderer3D.addBlock(`bullet${i}`, b.pos.x, b.pos.y, b.color?Number(b.color.replace('#','0x')):0xe8f5ff, b.radius*2));
-      this.enemies.forEach((e,i)=>renderer3D.addBlock(`enemy${i}`, e.pos.x, e.pos.y, 0xff0000, e.radius*2));
-      this.meteors.forEach((m,i)=>renderer3D.addBlock(`meteor${i}`, m.pos.x, m.pos.y, 0xff944d, m.radius*2));
-      this.player && renderer3D.addBlock('player', this.player.pos.x, this.player.pos.y, 0x00ff00, this.player.radius*2);
+
+      this.scenery.forEach((d,i)=>{
+        const sprite = Sprites[d.type];
+        if (sprite) renderer3D.addSprite(`scenery${i}`, sprite, d.x, d.y);
+      });
+
+      this.supplies.forEach((s,i)=>{
+        const sprite = s.type==='grenade'?Sprites.crateGren:s.type==='shotgun'?Sprites.crateShot:s.type==='missile'?Sprites.crateMiss:Sprites.crateGun;
+        renderer3D.addSprite(`supply${i}`, sprite, s.pos.x, s.pos.y, 0, 1.6);
+      });
+
+      this.grenades.forEach((gr,i)=>renderer3D.addSprite(`grenade${i}`, Sprites.grenade, gr.pos.x, gr.pos.y, 0, 1.6));
+
+      this.bullets.forEach((b,i)=>{
+        const ang = b.ang || (b.vel && b.vel.angle ? b.vel.angle() : 0);
+        renderer3D.addSprite(`bullet${i}`, Sprites.bullet, b.pos.x, b.pos.y, ang, b.radius/2);
+      });
+
+      this.enemies.forEach((e,i)=>{
+        let sprite, scale, ang = e.vel.angle();
+        if (e instanceof Raptor) { sprite = Sprites.raptor; scale = e.radius/12; }
+        else if (e instanceof WaterDino) { sprite = Sprites.waterdino; scale = e.radius/12; }
+        else if (e instanceof Pterodactyl) { sprite = Sprites.ptero; scale = e.radius/12; }
+        else if (e instanceof Mosasaurus) { sprite = Sprites.mosasaurus; scale = e.radius/24; }
+        else if (e instanceof TRex) { sprite = Sprites.trex; scale = e.radius/24; }
+        if (sprite) renderer3D.addSprite(`enemy${i}`, sprite, e.pos.x, e.pos.y, ang, scale);
+      });
+
+      this.meteors.forEach((m,i)=>renderer3D.addSprite(`meteor${i}`, Sprites.meteor, m.pos.x, m.pos.y, 0, m.radius/12));
+
+      if (this.player) {
+        renderer3D.addSprite('player', Sprites.player, this.player.pos.x, this.player.pos.y, this.player.aim.angle(), this.player.radius/12);
+      }
+
       this.particles.forEach((p,i)=>renderer3D.addBlock(`particle${i}`, p.pos.x, p.pos.y, 0xffffff, p.radius*2));
+
       renderer3D.render();
 
       const boss = this.boss;

--- a/renderer3d.js
+++ b/renderer3d.js
@@ -14,6 +14,7 @@ export class Renderer3D {
     light.position.set(0, 0, 1);
     this.scene.add(light);
     this.objects = new Map();
+    this.textureCache = new Map();
   }
 
   setSize(w, h) {
@@ -30,6 +31,11 @@ export class Renderer3D {
   clear() {
     for (const mesh of this.objects.values()) {
       this.scene.remove(mesh);
+      if (mesh.geometry) mesh.geometry.dispose();
+      if (mesh.material) {
+        if (mesh.material.map) mesh.material.map.dispose();
+        mesh.material.dispose();
+      }
     }
     this.objects.clear();
   }
@@ -39,6 +45,22 @@ export class Renderer3D {
     const material = new THREE.MeshLambertMaterial({ color });
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(x, -y, 0);
+    this.scene.add(mesh);
+    this.objects.set(id, mesh);
+    return mesh;
+  }
+
+  addSprite(id, image, x, y, angle = 0, scale = 1) {
+    let texture = this.textureCache.get(image);
+    if (!texture) {
+      texture = new THREE.CanvasTexture(image);
+      this.textureCache.set(image, texture);
+    }
+    const geometry = new THREE.PlaneGeometry(image.width * scale, image.height * scale);
+    const material = new THREE.MeshBasicMaterial({ map: texture, transparent: true, depthWrite: false });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(x, -y, 0);
+    mesh.rotation.z = -angle;
     this.scene.add(mesh);
     this.objects.set(id, mesh);
     return mesh;

--- a/test/renderer3d.test.js
+++ b/test/renderer3d.test.js
@@ -16,4 +16,10 @@ assert(mesh.geometry instanceof THREE.BoxGeometry, 'geometry');
 assert(mesh.material.color.getHex() === 0xff0000, 'color');
 assert(r.scene.children.includes(mesh), 'mesh added to scene');
 
+const sprite = { width: 10, height: 20 };
+const spriteMesh = r.addSprite('sprite', sprite, 5, 5, Math.PI / 4, 2);
+assert(spriteMesh.geometry instanceof THREE.PlaneGeometry, 'sprite geometry');
+assert(spriteMesh.material.map.image === sprite, 'sprite texture');
+assert(r.scene.children.includes(spriteMesh), 'sprite added to scene');
+
 console.log('renderer3d test passed');


### PR DESCRIPTION
## Summary
- render game entities using textured sprites in 3D
- add meteor sprite and sprite-based rendering for player, enemies, bullets, and scenery
- test sprite support in Renderer3D

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb196c0a68832db4ced6d661c59aa5