### PR TITLE
feat: add 3D models with perspective

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elisgames",
-  "version": "1.14.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elisgames",
-      "version": "1.14.0",
+      "version": "2.0.0",
       "dependencies": {
         "three": "^0.164.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elisgames",
-  "version": "1.14.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "test": "node test/audio.test.js && node test/scenery.test.js && node test/raptor.test.js && node test/projectiles.test.js && node test/player.test.js && node test/shotgun.test.js && node test/grenade.test.js && node test/special.test.js && node test/special-kill.test.js && node test/special-boss.test.js && node test/crate-sprite.test.js && node test/meteor.test.js && node test/water-sprites.test.js && node test/background.test.js && node test/bullet-draw.test.js && node test/hud-shotgun.test.js && node test/hud-missile.test.js && node test/missile-draw.test.js && node test/shotgun-fire.test.js && node test/missile.test.js && node test/player-hit.test.js && node test/boss-difficulty.test.js && node test/renderer3d.test.js && node test/renderer3d-cache.test.js && node test/renderer3d-dispose.test.js && node test/mouse-scale.test.js && node test/start-button.test.js",

--- a/test/renderer3d.test.js
+++ b/test/renderer3d.test.js
@@ -8,8 +8,9 @@ function assert(cond, msg) {
 const r = new Renderer3D(null);
 
 r.setSize(800, 600);
-assert(r.camera.right === 800, 'camera right');
-assert(r.camera.bottom === -600, 'camera bottom');
+assert(r.camera instanceof THREE.PerspectiveCamera, 'perspective camera');
+assert(r.camera.aspect === 800 / 600, 'camera aspect');
+assert(r.camera.position.x === 400 && r.camera.position.y === -300, 'camera position');
 
 const mesh = r.addBlock('player', 10, 20, 0xff0000, 30);
 assert(mesh.geometry instanceof THREE.BoxGeometry, 'geometry');
@@ -18,7 +19,8 @@ assert(r.scene.children.includes(mesh), 'mesh added to scene');
 
 const sprite = { width: 10, height: 20 };
 const spriteMesh = r.addSprite('sprite', sprite, 5, 5, Math.PI / 4, 2);
-assert(spriteMesh.geometry instanceof THREE.PlaneGeometry, 'sprite geometry');
+assert(spriteMesh.geometry instanceof THREE.BoxGeometry, 'sprite geometry');
+assert(Math.abs(spriteMesh.rotation.y + Math.PI / 4) < 1e-6, 'sprite rotation');
 assert(spriteMesh.material.map.image === sprite, 'sprite texture');
 assert(r.scene.children.includes(spriteMesh), 'sprite added to scene');
 


### PR DESCRIPTION
## Summary
- replace sprite planes with textured 3D boxes
- render scene with a tilted perspective camera
- bump version to 2.0.0

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb456f7ab0832d9c788e146d3b4a57